### PR TITLE
support . and , also support - for backward compatibility

### DIFF
--- a/bin/renv
+++ b/bin/renv
@@ -15,7 +15,11 @@ var environmentLocation = argv._[0];
 var environmentNames;
 
 if (argv._.length > 1) {
-  environmentNames = argv._[1].split("-");
+  if(argv._[1].indexOf("-") > -1){
+    environmentNames = argv._[1].split("-");
+  }else{
+    environmentNames = argv._[1].split(",");
+  }
 }
 
 renv.getEnv(environmentLocation, environmentNames, function (err, env) {

--- a/lib/renv.js
+++ b/lib/renv.js
@@ -7,7 +7,7 @@ module.exports = {
       if (error) {
         return callback(error);
       } else {
-      
+
         try {
           var environments = JSON.parse(body);
           if (!environments) {
@@ -21,21 +21,37 @@ module.exports = {
           if (!environmentNames) {
             environmentNames = [Object.keys(environments)[0]];
           }
-          
+
           var commonEnv = environments._;
 
           var env = _.extend({}, commonEnv);
 
-          _.forEach(environmentNames, function(environmentName){
-            if (!environments.hasOwnProperty(environmentName)) {
-              throw new Error("The environment name " + environmentName + " was not found");
+          _.forEach(environmentNames, function (environmentName) {
+            var name = environmentName;
+            var stage = null;
+            if (name.split(".").length > 1) {
+              //dealing with reserved `stage` keyword
+              name = environmentName.split(".")[0];
+              stage = environmentName.split(".")[1];
             }
 
-            if (!environments[environmentName] || typeof environments[environmentName] !== "object") {
-              throw new Error("The environment " + environmentName + " is null, undefined, or not an object");
+            if (!environments.hasOwnProperty(name)) {
+              throw new Error("The environment name " + name + " was not found");
             }
 
-            env = _.extend({}, env, environments[environmentName]);
+            if (!environments[name] || typeof environments[name] !== "object") {
+              throw new Error("The environment " + name + " is null, undefined, or not an object");
+            }
+
+            var temp = environments[name];
+
+            if (stage && temp.stage && temp.stage[stage]) {
+              // if `stage` is defined, otherwise we omit it
+              // delete reserved keyword `stage`
+              temp = _.omit(_.extend({}, temp, temp.stage[stage]), "stage");
+            }
+
+            env = _.extend({}, env, temp);
           });
 
           callback(null, env);


### PR DESCRIPTION
current `-` configuration string is still supported

new feature
1. allow flat data, split by `.`
2. allow structural data,  split by `,`