### PR TITLE
Add parse() to exported module

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ In the above example, using `local` or `production` will inherit `COMMONVAR` fro
 `renv` can also be used programmatically. If you want to fetch an environment in JS code, simply include `renv` as a module and call `getEnv()`, like this:
 
 ```javascript
-var renv = require("../lib/renv");
+var renv = require("testarmada-renv");
 renv.getEnv("https://example.com/env.json", ["myteam", "ci", "master"], function (err, env) {
 
   if (err) {
@@ -84,6 +84,8 @@ renv.getEnv("https://example.com/env.json", ["myteam", "ci", "master"], function
 
 });
 ```
+
+Please also see the programmatic API example on sub-environments and git project detection below. 
 
 # Defining Sub-environments
 
@@ -181,6 +183,26 @@ For example, if you have the following JSON environment file:
 ```
  
 The above snippet will inherit the common environment (`_`), followed by the project environment (`git@github.com:MyOrg/myproject.git`), followed by the sub-environment (`master`).
+
+# Using Git Sub-Environments Programmatically 
+
+If you want to auto-detect a git environment via `renv`'s programmatic API, use `renv.parse()`:
+
+```javascript
+var renv = require("testarmada-renv");
+// Use dot notation with renv.parse() to ask renv to auto-detect the sub-environment by the current git project. 
+renv.getEnv("https://example.com/env.json", renv.parse(".master")], function (err, env) {
+
+  if (err) {
+    console.error("error!", err);
+  } else {
+    console.log("got environment:", env);
+  }
+
+});
+```
+
+See the section above for a JSON file example for this use case.
 
 # :warning: Security Warning
 

--- a/lib/renv.js
+++ b/lib/renv.js
@@ -1,6 +1,7 @@
 const request = require("request");
 const _ = require("lodash");
 const RenvSet = require("../lib/renvset");
+const git = require("../lib/gitutil");
 const fs = require("fs");
 
 const fetchEnv = (environmentLocation, callback) => {
@@ -106,5 +107,11 @@ module.exports = {
         }
       }
     });
+  },
+
+  // Given a string like "myteam,master" or ".pr", return an array of RenvSet objects that
+  // can be given to getEnv() as a valid argument
+  parse: (argString) => {
+    return RenvSet.getSets(git.canonicalURL, argString);
   }
 };

--- a/test/renv.js
+++ b/test/renv.js
@@ -7,37 +7,64 @@ describe("renv", () => {
 
   describe("From a local JSON file", () => {
 
-    it("should get the common _ environment", () => {
-      renv.getEnv(TESTFILE, [], (err, env) => {
-        expect(env.COMMONVAR1).to.equal("abc123");
+    describe("Basic API", () => {
+
+      it("should get the common _ environment", () => {
+        renv.getEnv(TESTFILE, [], (err, env) => {
+          expect(env.COMMONVAR1).to.equal("abc123");
+        });
       });
+
+      it("should get a environment with no stage", () => {
+        renv.getEnv(TESTFILE, ["project1"], (err, env) => {
+          expect(env.COMMONVAR1).to.equal("abc123");
+          expect(env.PROJECTVAR1).to.equal("abc123");
+          expect(Object.keys(env).length).to.equal(2);
+        });
+      });
+
+      it("should get a sub-environment", () => {
+        renv.getEnv(TESTFILE, ["project1.pr"], (err, env) => {
+          expect(env.COMMONVAR1).to.equal("abc123");
+          expect(env.PROJECTVAR1).to.equal("abc123");
+          expect(env.PROJECTVAR2).to.equal("def456");
+          expect(Object.keys(env).length).to.equal(3);
+        });
+      });
+
+      it("should merge two sub-environments in order", () => {
+        renv.getEnv(TESTFILE, ["project1.pr","project1.master"], (err, env) => {
+          expect(env.COMMONVAR1).to.equal("abc123");
+          expect(env.PROJECTVAR1).to.equal("abc123");
+          expect(env.PROJECTVAR2).to.equal("ghi789");
+          expect(env.PROJECTVAR3).to.equal("jkl012");
+          expect(Object.keys(env).length).to.equal(4);
+        });
+      });
+
     });
 
-    it("should get a environment with no stage", () => {
-      renv.getEnv(TESTFILE, ["project1"], (err, env) => {
-        expect(env.COMMONVAR1).to.equal("abc123");
-        expect(env.PROJECTVAR1).to.equal("abc123");
-        expect(Object.keys(env).length).to.equal(2);
+    describe("parse() API", () => {
+      it("should produce the same results as the Basic API", () => {
+        renv.getEnv(TESTFILE, renv.parse("project1.pr,project1.master"), (err, env) => {
+          expect(env.COMMONVAR1).to.equal("abc123");
+          expect(env.PROJECTVAR1).to.equal("abc123");
+          expect(env.PROJECTVAR2).to.equal("ghi789");
+          expect(env.PROJECTVAR3).to.equal("jkl012");
+          expect(Object.keys(env).length).to.equal(4);
+        });
       });
-    });
 
-    it("should get a sub-environment", () => {
-      renv.getEnv(TESTFILE, ["project1.pr"], (err, env) => {
-        expect(env.COMMONVAR1).to.equal("abc123");
-        expect(env.PROJECTVAR1).to.equal("abc123");
-        expect(env.PROJECTVAR2).to.equal("def456");
-        expect(Object.keys(env).length).to.equal(3);
+      it("should detect the git project", () => {
+        renv.getEnv(TESTFILE, renv.parse(".master"), (err, env) => {
+          expect(env.COMMONVAR1).to.equal("abc123");
+          expect(env.PROJECTVAR1).to.equal("xyz999");
+          expect(env.PROJECTVAR2).to.equal("yyy999");
+          expect(env.PROJECTVAR3).to.equal("zzz111");
+          expect(Object.keys(env).length).to.equal(4);
+        });
       });
-    });
 
-    it("should merge two sub-environments in order", () => {
-      renv.getEnv(TESTFILE, ["project1.pr","project1.master"], (err, env) => {
-        expect(env.COMMONVAR1).to.equal("abc123");
-        expect(env.PROJECTVAR1).to.equal("abc123");
-        expect(env.PROJECTVAR2).to.equal("ghi789");
-        expect(env.PROJECTVAR3).to.equal("jkl012");
-        expect(Object.keys(env).length).to.equal(4);
-      });
     });
 
   });

--- a/test/test_env.json
+++ b/test/test_env.json
@@ -16,5 +16,20 @@
         "PROJECTVAR3": "jkl012"
       }
     }
+  },
+
+  "git@github.com:TestArmada/renv.git": {
+    "PROJECTVAR1": "xyz999",
+
+    "stage": {
+      "pr": {
+        "PROJECTVAR2": "yyy432"
+      },
+
+      "master": {
+        "PROJECTVAR2": "yyy999",
+        "PROJECTVAR3": "zzz111"
+      }
+    }
   }
 }


### PR DESCRIPTION
### Overview

This PR adds `parse()` to the exported module so that programmatic usage of `renv` can benefit from the same git project auto detection as offered in the CLI API.

### TODO before wrapping up:

  - [x] add documentation to `README`

/cc @archlichking @chaseadamsio 