### PR TITLE
Fix bug with shallow environment access

### DIFF
--- a/lib/renvset.js
+++ b/lib/renvset.js
@@ -2,7 +2,7 @@ function RenvSet (prefix, name) {
   // If prefix is set:
   //   - if `name` has a leading dot, `prefix` is used, and the leading dot is removed.
   //   - if `name` is in the form prefix.name, then the prefix in `name` is used.
-  //   - if `name` itself omits a prefix and has no dots, then `prefix` is used.
+  //   - if `name` itself omits a prefix and has no dots, then `prefix` is NOT used.
   // If prefix is not set:
   //   - if `name` itself omits a prefix but *includes* a leading dot ("."), throw an exception.
   //   - if `name` is in the form prefix.name, then the prefix in `name` is used.
@@ -19,9 +19,9 @@ function RenvSet (prefix, name) {
   this.prefix = null;
 
   if (prefix) {
-    this.prefix = prefix;
     if (name[0] === ".") {
       this.name = name.substr(1);
+      this.prefix = prefix;
     } else if (name.indexOf(".") > 0) {
       this.prefix = name.split(".")[0];
       this.name = name.split(".")[1];

--- a/test/renv.js
+++ b/test/renv.js
@@ -15,6 +15,14 @@ describe("renv", () => {
         });
       });
 
+      it("should support shallow environments", () => {
+        renv.getEnv(TESTFILE, ["sharedsettings"], (err, env) => {
+          expect(env.COMMONVAR1).to.equal("abc123");
+          expect(env.SHAREDVAR1).to.equal("987cba");
+          expect(Object.keys(env).length).to.equal(2);
+        });
+      });
+
       it("should get a environment with no stage", () => {
         renv.getEnv(TESTFILE, ["project1"], (err, env) => {
           expect(env.COMMONVAR1).to.equal("abc123");
@@ -55,6 +63,16 @@ describe("renv", () => {
         });
       });
 
+      it("should tolerate spaces and the same results as the Basic API", () => {
+        renv.getEnv(TESTFILE, renv.parse("   project1.pr,    project1.master   "), (err, env) => {
+          expect(env.COMMONVAR1).to.equal("abc123");
+          expect(env.PROJECTVAR1).to.equal("abc123");
+          expect(env.PROJECTVAR2).to.equal("ghi789");
+          expect(env.PROJECTVAR3).to.equal("jkl012");
+          expect(Object.keys(env).length).to.equal(4);
+        });
+      });
+
       it("should detect the git project", () => {
         renv.getEnv(TESTFILE, renv.parse(".master"), (err, env) => {
           expect(env.COMMONVAR1).to.equal("abc123");
@@ -62,6 +80,25 @@ describe("renv", () => {
           expect(env.PROJECTVAR2).to.equal("yyy999");
           expect(env.PROJECTVAR3).to.equal("zzz111");
           expect(Object.keys(env).length).to.equal(4);
+        });
+      });
+
+      it("should support shallow environments", () => {
+        renv.getEnv(TESTFILE, renv.parse("sharedsettings"), (err, env) => {
+          expect(env.COMMONVAR1).to.equal("abc123");
+          expect(env.SHAREDVAR1).to.equal("987cba");
+          expect(Object.keys(env).length).to.equal(2);
+        });
+      });
+
+      it("should support a mixture of shallow environments and dot notation", () => {
+        renv.getEnv(TESTFILE, renv.parse("sharedsettings,.master"), (err, env) => {
+          expect(env.COMMONVAR1).to.equal("abc123");
+          expect(env.SHAREDVAR1).to.equal("987cba");
+          expect(env.PROJECTVAR1).to.equal("xyz999");
+          expect(env.PROJECTVAR2).to.equal("yyy999");
+          expect(env.PROJECTVAR3).to.equal("zzz111");
+          expect(Object.keys(env).length).to.equal(5);
         });
       });
 

--- a/test/renvset.js
+++ b/test/renvset.js
@@ -31,9 +31,9 @@ describe("RenvSet", () => {
       expect(rs.name).to.equal("name");
     });
 
-    it("should set a supplied prefix if no prefix is given in the name itself", () => {
+    it("should NOT set a supplied prefix if dot notation isn't used", () => {
       const rs = new RenvSet(PREFIX, "name");
-      expect(rs.prefix).to.equal(PREFIX);
+      expect(rs.prefix).to.equal(null);
       expect(rs.name).to.equal("name");
     });
 

--- a/test/test_env.json
+++ b/test/test_env.json
@@ -3,6 +3,10 @@
     "COMMONVAR1": "abc123" 
   },
 
+  "sharedsettings": {
+    "SHAREDVAR1": "987cba"
+  },
+
   "project1": {
     "PROJECTVAR1": "abc123",
 


### PR DESCRIPTION
This PR:

  - Fixes a bug where accessing "shallow" environments (i.e. RENV sets like `sharedsettings`) is broken if a prefix has been supplied for any reason (whether by detection or explicit argument).
  - In this fix, **only explicit dot notation will cause a prefix to be set**
  - Unit tests added to cover this case.
  - Sneak in an extra unit test case to check if `parse()` handles RENV strings with whitespace properly.

/cc @archlichking 