### PR TITLE
Add dot set addressing (addressing for the project environment only, without subenvironments)

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,14 @@ For example, if you have the following JSON environment file:
  
 The above snippet will inherit the common environment (`_`), followed by the project environment (`git@github.com:MyOrg/myproject.git`), followed by the sub-environment (`master`).
 
+To just get the project environment with no sub-environment, simply use a dot (`.`):
+
+```shell
+> eval $(./node_modules/.bin/renv https://example.com/env.json .)
+```
+
+The above snippet will inherit the common environment (`_`), followed by the project environment (`git@github.com:MyOrg/myproject.git`) (i.e. just `THRESHOLD` in the above example).
+
 # Using Git Sub-Environments Programmatically 
 
 If you want to auto-detect a git environment via `renv`'s programmatic API, use `renv.parse()`:

--- a/lib/renv.js
+++ b/lib/renv.js
@@ -72,18 +72,27 @@ module.exports = {
                 throw new Error("The environment " + prefix + " is not a valid object");
               }
 
-              if (typeof foundEnv.stage !== "object") {
-                throw new Error("The environment " + prefix + " does not have a stage for "
-                  + "sub-environments. Cannot find sub-environment " + name);
+              // if the name is just a dot, we just want the set defined AT
+              // the prefix, not any of its children. This is useful for prefixes that
+              // would have to be written as canonical git URLs in order to work, making
+              // parsing difficult.
+              if (name === ".") {
+                temp = _.omit(_.extend({}, foundEnv), "stage");
+              } else {
+                if (typeof foundEnv.stage !== "object") {
+                  throw new Error("The environment " + prefix + " does not have a stage for "
+                    + "sub-environments. Cannot find sub-environment " + name);
+                }
+
+                const foundSubEnv = foundEnv.stage[name];
+
+                if (typeof foundSubEnv !== "object") {
+                  throw new Error("The sub-environment " + name + " is not a valid object");
+                }
+
+                temp = _.omit(_.extend({}, foundEnv, foundSubEnv), "stage");
               }
 
-              const foundSubEnv = foundEnv.stage[name];
-
-              if (typeof foundSubEnv !== "object") {
-                throw new Error("The sub-environment " + name + " is not a valid object");
-              }
-
-              temp = _.omit(_.extend({}, foundEnv, foundSubEnv), "stage");
               env = _.extend({}, env, temp);
 
             } else {

--- a/lib/renvset.js
+++ b/lib/renvset.js
@@ -1,6 +1,7 @@
 function RenvSet (prefix, name) {
   // If prefix is set:
   //   - if `name` has a leading dot, `prefix` is used, and the leading dot is removed.
+  //   - if `name` is just a dot, `prefix` is used, and the dot is kept and maps to the set denoted by the prefix itself
   //   - if `name` is in the form prefix.name, then the prefix in `name` is used.
   //   - if `name` itself omits a prefix and has no dots, then `prefix` is NOT used.
   // If prefix is not set:
@@ -19,7 +20,11 @@ function RenvSet (prefix, name) {
   this.prefix = null;
 
   if (prefix) {
-    if (name[0] === ".") {
+    // Just a dot
+    if (name === ".") {
+      this.name = ".";
+      this.prefix = prefix;
+    } else if (name[0] === ".") {
       this.name = name.substr(1);
       this.prefix = prefix;
     } else if (name.indexOf(".") > 0) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testarmada-renv",
-  "version": "3.0.1",
+  "version": "4.0.0",
   "description": "Mix environment variables into current bash context from a remote location, with profiles",
   "main": "index.js",
   "scripts": {

--- a/test/renv.js
+++ b/test/renv.js
@@ -83,6 +83,14 @@ describe("renv", () => {
         });
       });
 
+      it("should detect the git project and return the shallow set when dot notation is used", () => {
+        renv.getEnv(TESTFILE, renv.parse("."), (err, env) => {
+          expect(env.COMMONVAR1).to.equal("abc123");
+          expect(env.PROJECTVAR1).to.equal("xyz999");
+          expect(Object.keys(env).length).to.equal(2);
+        });
+      });
+
       it("should support shallow environments", () => {
         renv.getEnv(TESTFILE, renv.parse("sharedsettings"), (err, env) => {
           expect(env.COMMONVAR1).to.equal("abc123");

--- a/test/renvset.js
+++ b/test/renvset.js
@@ -31,6 +31,12 @@ describe("RenvSet", () => {
       expect(rs.name).to.equal("name");
     });
 
+    it("should set a supplied prefix if the set name is a dot", () => {
+      const rs = new RenvSet(PREFIX, ".");
+      expect(rs.prefix).to.equal(PREFIX);
+      expect(rs.name).to.equal(".");
+    });
+
     it("should NOT set a supplied prefix if dot notation isn't used", () => {
       const rs = new RenvSet(PREFIX, "name");
       expect(rs.prefix).to.equal(null);
@@ -56,6 +62,11 @@ describe("RenvSet", () => {
       const rs = new RenvSet(null, "name");
       expect(rs.prefix).to.equal(null);
       expect(rs.name).to.equal("name");
+    });
+
+    it("should throw an error if no prefix is given in the name itself and the set name is a dot", () => {
+      const badFn = () => new RenvSet(null, ".");
+      expect(badFn).to.throw(Error);
     });
 
   });


### PR DESCRIPTION
Given the following environment file:

```json
{
  "_": {
    "COMMONVAR": "inherited by all other named environments"
  },
  "git@github.com:MyOrg/myproject.git": {
    "THRESHOLD": "0.75",
    "stage": {
      "pr": {
        "TEST_FILTER": "smoke",
        "DASHBOARD_TOKEN": "28931"
      },
      "master": {
        "TEST_FILTER": "regression",
        "DASHBOARD_TOKEN": "139611"        
      }
    }
  }
}
```

In the current implementation of `renv`, there is no way to use git project detection and **only** fetch the project environment **without the sub-environments `master` and `pr`**.

For example, with the above environment file, we have no way of **just** fetching `THRESHOLD` and ignoring the settings in `pr` and `master`, if we want to benefit from renv's git auto-detect feature.

This PR adds support for a set called `.`. For the above example, the `.` set gets you just the  `THRESHOLD` property (along with the `COMMONVAR` inherited from `_`, the common set).

Tests included.

/cc @archlichking @geekdave @ThaiWood 