### PR TITLE
Fix Travis integration: Always normalize canonical git urls to git@ form

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - v7
+  - v6
+  - v5
+  - v4
+sudo: false

--- a/lib/gitutil.js
+++ b/lib/gitutil.js
@@ -1,6 +1,7 @@
 module.exports = {
   // Return undefined if a canonical git URL can't be determined.
   // Return the canonical git URL if this is a git project and git is installed.
+  // Always return canonical git URL in git@ (ssh) style format
   // Note: This method should always be safe to call even if git isn't installed.
   get canonicalURL() {
     var result;
@@ -9,6 +10,20 @@ module.exports = {
     } catch (childProcessException) {
       // result will be undefined.
     }
+
+    // convert: https://githubhost/orgname/reponame.git
+    // into: git@githubhost:orgname/reponame.git
+
+    // if we don't have an ssh-style URL, convert it
+    if (result.indexOf("git") !== 0) {
+      const suffix = result.split("://")[1]; 
+      const host = suffix.split("/")[0];
+      const path = suffix.substring(suffix.indexOf("/") + 1);
+      const orgname = path.split("/")[0];
+      const repoSuffix = path.split("/")[1];
+      result = `git@${host}:${orgname}/${repoSuffix}`;
+    }
+
     return result;
   } 
 };


### PR DESCRIPTION
**Summary:** This PR fixes the issues we've had in enabling our unit tests to work on Travis and other CI environments that don't use the ssh URL when cloning a git project.

This fix ensures we always normalize git URLs to a `git@` form, which ensures that regardless of which environment `renv` is used in, one form of git URL can be used. Some CI environments pull from `https` git URLs instead of the ssh form.

This PR also would fix the issue that we have in bringing in a `.travis.yml`, which should finally unlock the existing unit test suite for this project.

/cc @jherr 